### PR TITLE
Changes from background agent bc-d7af0f8c-34ae-4e5b-b7dc-b2c2730f5580

### DIFF
--- a/repo/swift/apple/retail/foundations/unisight_lib/Sources/UnisightLib/Core/ManualTelemetryExporter.swift
+++ b/repo/swift/apple/retail/foundations/unisight_lib/Sources/UnisightLib/Core/ManualTelemetryExporter.swift
@@ -90,13 +90,13 @@ public class ManualTelemetryExporter: SpanExporter, MetricExporter {
         return flush()
     }
 
-     public func shutdown() {
-           session.invalidateAndCancel()
-       }
+    public func shutdown() {
+        session.invalidateAndCancel()
+    }
 
-       public func shutdown(explicitTimeout: TimeInterval?) {
-           (self as SpanExporter).shutdown()
-       }
+    public func shutdown(explicitTimeout: TimeInterval?) {
+        shutdown()
+    }
 
     // MARK: - MetricExporter Protocol
     public func export(metrics: [Metric]) -> MetricExporterResultCode {


### PR DESCRIPTION
Refactor `shutdown` method in `ManualTelemetryExporter` to resolve ambiguity.

The `ManualTelemetryExporter` conforms to both `SpanExporter` and `MetricExporter`, both of which define a `shutdown()` method (one returning `Void`, the other `ExportResult`). This caused an ambiguous call to `shutdown()` within the `shutdown(explicitTimeout:)` method. The change clarifies the intended `shutdown()` call, resolving the ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7af0f8c-34ae-4e5b-b7dc-b2c2730f5580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7af0f8c-34ae-4e5b-b7dc-b2c2730f5580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>